### PR TITLE
preload video on root page

### DIFF
--- a/frontend/src/components/app.tsx
+++ b/frontend/src/components/app.tsx
@@ -50,6 +50,9 @@ const App: FunctionalComponent = () => {
           <NotFoundPage default />
         </Router>
       </Provider>
+      <video class="hidden-video" autoPlay muted>
+        <source src="/assets/images/bg-15-15-gray-480p.mp4" type="video/mp4" />
+      </video>
     </div>
   )
 }

--- a/frontend/src/style/index.css
+++ b/frontend/src/style/index.css
@@ -66,6 +66,11 @@ h2 {
   height: 100px;
 }
 
+.hidden-video {
+  height: 0;
+  opacity: 0;
+}
+
 @media (min-width: 992px) {
   #app {
     background: #bbb8b6;


### PR DESCRIPTION
preload video on root page so that video is already loaded in browser cache before it is displayed on the chat page