### PR TITLE
add debug mode at /debug

### DIFF
--- a/frontend/src/components/app.tsx
+++ b/frontend/src/components/app.tsx
@@ -1,5 +1,6 @@
 import { FunctionalComponent, h } from "preact"
-import { Route, Router, RouterOnChangeArgs, Link } from "preact-router"
+import { route, Route, Router, RouterOnChangeArgs } from "preact-router"
+import { Match } from "preact-router/match"
 import { Provider } from "react-redux"
 
 import Welcome from "../routes/welcome"
@@ -13,6 +14,7 @@ import { store } from "../lib/store"
 import CameraError from "../routes/camera-error"
 import { ReloadLink } from "./reload-link"
 import { addMessage } from "../lib/logging"
+import { setDebugMode } from "../lib/app-acts-config"
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 if ((module as any).hot) {
@@ -40,6 +42,16 @@ const App: FunctionalComponent = () => {
           <Route path="/versus" component={DoJob} />
           <Route path="/job-summary" component={JobSummary} />
           <Route path="/epilogue" component={Epilogue} />
+          <Match path="/debug">
+            {({ matches }: { matches: boolean }): null => {
+              if (matches) {
+                console.warn("Entering debug mode")
+                setDebugMode(true)
+                route("/", true)
+              }
+              return null
+            }}
+          </Match>
           {/* component example routes */}
           <Route
             path="/example/auto-advance-button"
@@ -50,7 +62,7 @@ const App: FunctionalComponent = () => {
           <NotFoundPage default />
         </Router>
       </Provider>
-      <video class="hidden-video" autoplay muted playsinline>
+      <video class="hidden-video" autoPlay muted playsinline>
         <source src="/assets/images/bg-15-15-gray-480p.mp4" type="video/mp4" />
       </video>
     </div>

--- a/frontend/src/components/battle/index.tsx
+++ b/frontend/src/components/battle/index.tsx
@@ -12,8 +12,8 @@ import { TraitLabel } from "../../lib/face-reader-labels"
 import TimeLimitDisplay from "../time-limit-display"
 import JobScoreDisplay from "../job-score-display"
 
-import { DoJobConfig } from "../../lib/app-acts-config"
-const { scoringTimeLimit } = DoJobConfig
+import { DoJobConfig, getScoringTimeLimit } from "../../lib/app-acts-config"
+const scoringTimeLimit = getScoringTimeLimit(DoJobConfig)
 
 /** Displays dotted circle and feature text */
 const FaceHint: FunctionalComponent<{

--- a/frontend/src/components/chat-overlay/index.tsx
+++ b/frontend/src/components/chat-overlay/index.tsx
@@ -2,12 +2,15 @@ import { FunctionalComponent, h } from "preact"
 import AutoAdvanceButton from "../auto-advance-button"
 import * as style from "./style.css"
 import { useState, useEffect } from "preact/hooks"
-import { IntermediateAct, firstActId, ActId } from "../../lib/app-acts-config"
+import {
+  IntermediateAct,
+  firstActId,
+  ActId,
+  getAutoclickTimeout
+} from "../../lib/app-acts-config"
 
 import { ChatPageConfig } from "../../lib/app-acts-config"
-const {
-  nextButton: { autoclickTimeout }
-} = ChatPageConfig
+const autoclickTimeout = getAutoclickTimeout(ChatPageConfig)
 
 const ChatMessages: FunctionalComponent<{
   messages: ReadonlyArray<string>
@@ -64,7 +67,7 @@ const ChatOverlay: FunctionalComponent<ChatOverlayProps> = props => {
           onClick={(): void => onAdvance(actId)}
         />
       ) : null}
-      <video class={style.videoBackground} autoplay muted playsinline loop>
+      <video class={style.videoBackground} autoPlay muted playsinline loop>
         <source src="/assets/images/bg-15-15-gray-480p.mp4" type="video/mp4" />
       </video>
     </div>

--- a/frontend/src/lib/app-acts-config.ts
+++ b/frontend/src/lib/app-acts-config.ts
@@ -1,3 +1,4 @@
+import DoJob from "../routes/do-job"
 import { PotentialJob } from "./job"
 
 /** (Literal) id for the first act */
@@ -449,6 +450,12 @@ type BasePageConfig = {
   }
 }
 
+let debugMode = false
+
+export const setDebugMode = (val: boolean): void => {
+  debugMode = val
+}
+
 export const ChooseJobConfig: BasePageConfig = {
   nextButton: {
     autoclickTimeout: 10 * 1000
@@ -465,11 +472,16 @@ export const JobSummaryConfig: BasePageConfig = {
     autoclickTimeout: 10 * 1000
   }
 }
-export const ChatPageConfig: BasePageConfig & {
-  messageAppearanceInterval: number
-} = {
+export const ChatPageConfig: BasePageConfig = {
   nextButton: {
     autoclickTimeout: 10 * 1000
-  },
-  messageAppearanceInterval: 2000
+  }
 }
+
+export const getAutoclickTimeout = (config: BasePageConfig): number =>
+  !debugMode
+    ? config.nextButton.autoclickTimeout
+    : config.nextButton.autoclickTimeout / 3
+
+export const getScoringTimeLimit = (config: typeof DoJobConfig): number =>
+  !debugMode ? config.scoringTimeLimit : 5000

--- a/frontend/src/routes/choose-job/index.tsx
+++ b/frontend/src/routes/choose-job/index.tsx
@@ -1,5 +1,9 @@
 import { FunctionalComponent, h } from "preact"
-import { ActsConfig } from "../../lib/app-acts-config"
+import {
+  ActId,
+  ActsConfig,
+  getAutoclickTimeout
+} from "../../lib/app-acts-config"
 import { route, Link } from "preact-router"
 import AutoAdvanceButton from "../../components/auto-advance-button"
 import { AtopVideoSelfie } from "../../components/videoselfie"
@@ -8,10 +12,8 @@ import { toDollars, PotentialJob, getStartingBalance } from "../../lib/job"
 import JobCaricature from "../../components/job-caricature"
 import * as style from "./style.css"
 
-import { ActId, ChooseJobConfig } from "../../lib/app-acts-config"
-const {
-  nextButton: { autoclickTimeout }
-} = ChooseJobConfig
+import { ChooseJobConfig } from "../../lib/app-acts-config"
+const autoclickTimeout = getAutoclickTimeout(ChooseJobConfig)
 
 const verusUrl = "/versus/"
 

--- a/frontend/src/routes/do-job/index.tsx
+++ b/frontend/src/routes/do-job/index.tsx
@@ -1,15 +1,18 @@
 import { FunctionalComponent, h } from "preact"
 import Battle from "../../components/battle"
-import { Link, route } from "preact-router"
+import { route } from "preact-router"
 import { useState, useCallback } from "preact/hooks"
 import AutoAdvanceButton from "../../components/auto-advance-button"
 import { useTypedSelector, pushCompletedJob, store } from "../../lib/store"
 import * as style from "./style.css"
-import { DoJobConfig, ActsConfig } from "../../lib/app-acts-config"
+import {
+  DoJobConfig,
+  ActsConfig,
+  getAutoclickTimeout
+} from "../../lib/app-acts-config"
 import { PotentialJob, completeJob } from "../../lib/job"
-const {
-  nextButton: { autoclickTimeout }
-} = DoJobConfig
+
+const autoclickTimeout = getAutoclickTimeout(DoJobConfig)
 
 const getCurrentJob = (): PotentialJob => {
   const currentJob = useTypedSelector(state => state.currentJob)

--- a/frontend/src/routes/job-summary/index.tsx
+++ b/frontend/src/routes/job-summary/index.tsx
@@ -11,7 +11,8 @@ import {
   ActsConfig,
   IntermediateAct,
   firstActId,
-  finalActId
+  finalActId,
+  getAutoclickTimeout
 } from "../../lib/app-acts-config"
 import {
   toDollars,
@@ -19,13 +20,11 @@ import {
   getJobGrandTotal,
   getStartingBalance
 } from "../../lib/job"
+import { addMessage } from "../../lib/logging"
 import * as style from "./style.css"
 
 import { JobSummaryConfig } from "../../lib/app-acts-config"
-import { addMessage } from "../../lib/logging"
-const {
-  nextButton: { autoclickTimeout }
-} = JobSummaryConfig
+const autoclickTimeout = getAutoclickTimeout(JobSummaryConfig)
 
 const JobSummary: FunctionalComponent = () => {
   const [showChat, setShowChat] = useState(false)


### PR DESCRIPTION
i missed that #9 was closed before i finished this! 😅

when you go to `/debug`, it sets a flag that shortens all of the timers (including the "do job" length) and then puts you on the home page to start.

@kylemcdonald i this still helpful? i'm not in love with my solution here so i won't be upset at all if we toss it. and we might have to figure out how to fix our netlify 404 error for this to work once its deployed (https://community.netlify.com/t/support-guide-i-ve-deployed-my-site-but-i-still-see-page-not-found/125/11)