### PR TITLE
prevent html element from scrolling

### DIFF
--- a/frontend/src/style/index.css
+++ b/frontend/src/style/index.css
@@ -26,7 +26,12 @@ body {
   -moz-osx-font-smoothing: grayscale;
   min-width: 400px;
 }
-
+html {
+  overflow: hidden;
+}
+body {
+  overflow: auto;
+}
 * {
   box-sizing: border-box;
 }


### PR DESCRIPTION
closes #67 

- add `overflow: hidden` to html element so the page doesn't bump
- add `overflow: auto` to body element so page still scrolls when it needs to